### PR TITLE
MagicCircle: noFill() to prevent fill in elipse

### DIFF
--- a/Processing/magicCircle.pde
+++ b/Processing/magicCircle.pde
@@ -31,6 +31,7 @@ class MagicCircle{
   }
   void update(){
     pushMatrix();
+    noFill();
     translate(elipseData.centerPosition.x, elipseData.centerPosition.y);
     rotate(elipseData.angle);
     ellipse(0, 0, elipseData.length, elipseData.width);


### PR DESCRIPTION
Solving the issue #13.
Use of noFill()